### PR TITLE
Fix newline issues in docs and scripts

### DIFF
--- a/APACHE_DEPLOYMENT.md
+++ b/APACHE_DEPLOYMENT.md
@@ -190,3 +190,4 @@ The Apache configuration includes:
 - **Hidden sensitive files** (.env, .git, etc.)
 
 The site is fully production-ready for Apache deployment!
+

--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -55,3 +55,4 @@ dist/
 - If you move files to `dist/`, you may need to update server configurations accordingly
 - Always run the build command before running the move scripts
 - The scripts will overwrite existing files in the target location
+

--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -88,3 +88,4 @@ After deployment:
 - [ ] Cache cleared (browser + server)?
 - [ ] Correct branch deployed (main/master)?
 - [ ] Build output directory correct?
+

--- a/HOSTINGER_DEPLOYMENT.md
+++ b/HOSTINGER_DEPLOYMENT.md
@@ -148,3 +148,4 @@ After deployment, test these URLs:
 - `https://yourdomain.com/technology` → Technology page
 
 All should load without 403 errors.
+

--- a/build-hostinger.sh
+++ b/build-hostinger.sh
@@ -48,3 +48,4 @@ echo "2. git commit -m 'fix: build output for Hostinger deployment'"
 echo "3. git push"
 echo ""
 echo "Hostinger will automatically deploy from dist/ to public_html/"
+

--- a/deploy-hostinger.js
+++ b/deploy-hostinger.js
@@ -67,3 +67,4 @@ try {
   console.error('❌ Error during deployment preparation:', error.message);
   process.exit(1);
 }
+

--- a/deploy.sh
+++ b/deploy.sh
@@ -20,3 +20,4 @@ rsync -a --delete dist/ .
 if ! grep -q "FallbackResource" .htaccess 2>/dev/null; then
   echo "FallbackResource /index.html" >> .htaccess
 fi
+

--- a/hostinger-deploy.js
+++ b/hostinger-deploy.js
@@ -70,3 +70,4 @@ console.log('1. git add -A dist');
 console.log('2. git commit -m "fix: build output for Hostinger deployment"');
 console.log('3. git push');
 console.log('\nHostinger will deploy files from dist/ to public_html/');
+

--- a/move-index.js
+++ b/move-index.js
@@ -32,3 +32,4 @@ try {
   console.error('Error moving file:', error);
   process.exit(1);
 }
+

--- a/move-index.sh
+++ b/move-index.sh
@@ -38,3 +38,4 @@ else
     echo "Error: Failed to copy file"
     exit 1
 fi
+

--- a/replit.md
+++ b/replit.md
@@ -118,3 +118,4 @@ qBTC is a quantum-resistant Bitcoin sidechain application built as a full-stack 
 ## User Preferences
 
 Preferred communication style: Simple, everyday language.
+


### PR DESCRIPTION
## Summary
- add missing newline characters at end of docs and scripts to clean up repo

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_686af685ab8483229a93c1fa4880dea9